### PR TITLE
feat: Support unconventional resume sections

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 
 def parse_cors_origins() -> list[str]:
     """Parse CORS_ORIGINS from environment, handling various formats."""
-    default = ["http://localhost:3000", "https://restailor.vercel.app"]
+    default = ["http://localhost:3000", "http://localhost:3001", "https://restailor.vercel.app"]
     
     raw = os.environ.get("CORS_ORIGINS", "")
     if not raw:

--- a/backend/app/models/atomic_unit.py
+++ b/backend/app/models/atomic_unit.py
@@ -8,11 +8,16 @@ from pydantic import BaseModel, Field
 
 class AtomicUnitType(str, Enum):
     """Type of atomic unit."""
-    BULLET = "bullet"
-    SKILL_GROUP = "skill_group"
-    EDUCATION = "education"
-    PROJECT = "project"
-    HEADER = "header"
+    BULLET = "bullet"           # A bullet point (experience, involvement, etc.)
+    SKILL_GROUP = "skill_group" # A group of skills
+    EDUCATION = "education"     # An education entry
+    PROJECT = "project"         # A project entry
+    HEADER = "header"           # Header info (name, contact)
+    AWARD = "award"             # An award or honor
+    CERTIFICATION = "certification"  # A certification
+    PUBLICATION = "publication" # A publication
+    LANGUAGE = "language"       # A language entry
+    INTEREST = "interest"       # An interest/hobby
 
 
 class SectionType(str, Enum):
@@ -22,6 +27,17 @@ class SectionType(str, Enum):
     EDUCATION = "education"
     SKILLS = "skills"
     HEADER = "header"
+    # Additional sections (issue #28)
+    INVOLVEMENT = "involvement"     # Activities, clubs, organizations
+    LEADERSHIP = "leadership"       # Leadership roles
+    VOLUNTEER = "volunteer"         # Volunteer experience
+    AWARDS = "awards"               # Awards and honors
+    CERTIFICATIONS = "certifications"  # Professional certifications
+    PUBLICATIONS = "publications"   # Papers, articles, books
+    LANGUAGES = "languages"         # Language proficiencies
+    INTERESTS = "interests"         # Hobbies and interests
+    # Catch-all for unrecognized sections
+    OTHER = "other"                 # Any section not matching above
 
 
 class DateRange(BaseModel):

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -13,14 +13,14 @@ from app.db.mongodb import get_database
 
 EXTRACTION_PROMPT = """
 You are a resume parser. Extract ALL content from this resume into atomic units.
-Each unit is ONE bullet point, skill group, education entry, or project.
+Each unit is ONE bullet point, skill group, education entry, project, award, etc.
 
 Return a JSON array. For EACH unit, include:
 {
-  "type": "bullet" | "skill_group" | "education" | "project" | "header",
-  "section": "experience" | "projects" | "education" | "skills" | "header",
-  "org": "company/school name (or null)",
-  "role": "job title or degree (or null)",
+  "type": "bullet" | "skill_group" | "education" | "project" | "header" | "award" | "certification" | "publication" | "language" | "interest",
+  "section": "experience" | "projects" | "education" | "skills" | "header" | "involvement" | "leadership" | "volunteer" | "awards" | "certifications" | "publications" | "languages" | "interests" | "other",
+  "org": "company/school/organization name (or null)",
+  "role": "job title, degree, or position (or null)",
   "dates": {"start": "YYYY-MM or null", "end": "YYYY-MM or present or null"},
   "text": "EXACT text from resume - DO NOT modify, summarize, or expand",
   "tags": {
@@ -30,6 +30,21 @@ Return a JSON array. For EACH unit, include:
   }
 }
 
+SECTION MAPPING:
+- Experience, Work History, Employment → section: "experience", type: "bullet"
+- Projects, Personal Projects → section: "projects", type: "project"
+- Education, Academic → section: "education", type: "education"
+- Skills, Technical Skills → section: "skills", type: "skill_group"
+- Involvement, Activities, Clubs, Organizations → section: "involvement", type: "bullet"
+- Leadership, Leadership Experience → section: "leadership", type: "bullet"
+- Volunteer, Community Service → section: "volunteer", type: "bullet"
+- Awards, Honors, Achievements → section: "awards", type: "award"
+- Certifications, Licenses → section: "certifications", type: "certification"
+- Publications, Papers, Research → section: "publications", type: "publication"
+- Languages → section: "languages", type: "language"
+- Interests, Hobbies → section: "interests", type: "interest"
+- Any other unrecognized section → section: "other", type: "bullet"
+
 CRITICAL RULES:
 1. Use ONLY text that appears VERBATIM in the resume
 2. Do NOT infer, expand, or add any information
@@ -37,7 +52,8 @@ CRITICAL RULES:
 4. If dates are unclear, use null
 5. Extract EVERY bullet point, even short ones
 6. For skills section, create one skill_group per category
-7. Include header info (name, contact) as type "header"
+7. Include header info (name, contact) as type "header", section "header"
+8. Recognize ALL sections, not just standard ones
 
 Resume text:
 """
@@ -93,23 +109,93 @@ async def ingest_pdf(pdf_content: bytes, filename: str) -> MasterResumeResponse:
     # Map invalid types to valid AtomicUnitTypes
     # Gemini sometimes confuses section names with type names
     TYPE_MAPPING = {
-        "experience": "bullet",      # Experience items are bullets
-        "projects": "project",       # Projects section -> project type
-        "skills": "skill_group",     # Skills section -> skill_group type
+        # Standard types (valid as-is)
         "bullet": "bullet",
         "skill_group": "skill_group",
         "education": "education",
         "project": "project",
         "header": "header",
+        "award": "award",
+        "certification": "certification",
+        "publication": "publication",
+        "language": "language",
+        "interest": "interest",
+        # Section names that should map to types
+        "experience": "bullet",
+        "projects": "project",
+        "skills": "skill_group",
+        "involvement": "bullet",
+        "leadership": "bullet",
+        "volunteer": "bullet",
+        "awards": "award",
+        "certifications": "certification",
+        "publications": "publication",
+        "languages": "language",
+        "interests": "interest",
+        # Common variations
+        "activities": "bullet",
+        "honors": "award",
+        "achievements": "award",
+        "papers": "publication",
+        "research": "publication",
+        "hobbies": "interest",
+    }
+    
+    # Map section name variations to standard SectionType values
+    SECTION_MAPPING = {
+        "experience": "experience",
+        "work": "experience",
+        "work experience": "experience",
+        "employment": "experience",
+        "projects": "projects",
+        "personal projects": "projects",
+        "education": "education",
+        "academic": "education",
+        "skills": "skills",
+        "technical skills": "skills",
+        "header": "header",
+        "involvement": "involvement",
+        "activities": "involvement",
+        "clubs": "involvement",
+        "organizations": "involvement",
+        "extracurricular": "involvement",
+        "leadership": "leadership",
+        "leadership experience": "leadership",
+        "volunteer": "volunteer",
+        "volunteering": "volunteer",
+        "community service": "volunteer",
+        "awards": "awards",
+        "honors": "awards",
+        "achievements": "awards",
+        "certifications": "certifications",
+        "licenses": "certifications",
+        "certificates": "certifications",
+        "publications": "publications",
+        "papers": "publications",
+        "research": "publications",
+        "languages": "languages",
+        "interests": "interests",
+        "hobbies": "interests",
+        "other": "other",
     }
     
     for i, raw in enumerate(raw_units):
         try:
+            # Normalize section - map variations to standard names
+            raw_section = raw.get("section", "experience").lower()
+            normalized_section = SECTION_MAPPING.get(raw_section, raw_section)
+            
+            # Fall back to 'other' if section is completely unknown
+            # This preserves unrecognized sections instead of losing context
+            valid_sections = [s.value for s in SectionType]
+            if normalized_section not in valid_sections:
+                normalized_section = "other"
+                warnings.append(f"Unit {i}: Unknown section '{raw_section}' mapped to 'other'")
+            
             # Generate unique ID
-            section = raw.get("section", "experience")
             org = raw.get("org", "unknown")
             org_slug = "".join(c for c in (org or "unknown")[:10].lower() if c.isalnum())
-            unit_id = f"{section[:3]}_{org_slug}_{i:03d}"
+            unit_id = f"{normalized_section[:3]}_{org_slug}_{i:03d}"
             
             # Parse dates
             dates = None
@@ -134,7 +220,7 @@ async def ingest_pdf(pdf_content: bytes, filename: str) -> MasterResumeResponse:
             unit = AtomicUnit(
                 id=unit_id,
                 type=AtomicUnitType(normalized_type),
-                section=SectionType(raw.get("section", "experience")),
+                section=SectionType(normalized_section),
                 org=raw.get("org"),
                 role=raw.get("role"),
                 dates=dates,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1057,7 +1057,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1069,7 +1068,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1207,7 +1205,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1623,7 +1620,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -1925,7 +1921,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2095,7 +2090,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2108,7 +2102,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2462,7 +2455,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
## Summary
- Add support for extracting non-standard resume sections (involvement, leadership, volunteer, awards, certifications, publications, languages, interests)
- Add new SectionType and AtomicUnitType enums for all section categories
- Implement TYPE_MAPPING to normalize Gemini's varied output (e.g., 'experience' -> 'bullet')
- Implement SECTION_MAPPING for handling section name variations (e.g., 'Activities' -> 'involvement')
- Add 'other' as catch-all section for unrecognized sections

## Test plan
- [ ] Upload a resume with awards/certifications/involvement sections
- [ ] Verify atomic units are extracted with correct section and type
- [ ] Check Vault displays all section types correctly

Closes #28