### PR TITLE
fix(tests): correct mock targets for Python 3.11 compat

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,6 +1,6 @@
 """Integration tests for the FastAPI checkpoints."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -33,7 +33,7 @@ async def test_health_check(async_client):
 
 
 @pytest.mark.asyncio
-async def test_parse_job_url(async_client, mock_services, mock_external_deps):
+async def test_parse_job_url(async_client, mock_services):
     """Test the job parsing endpoint."""
     mock_jd_data = {
         "jd_id": "test_jd",
@@ -53,8 +53,9 @@ async def test_parse_job_url(async_client, mock_services, mock_external_deps):
     # Mock services
     mock_services["parse_job_description"].return_value = mock_jd
 
-    # Mock DB from global fixture
-    mock_db = mock_external_deps["db"]
+    # Mock DB via mock_services (patches app.routers.job.get_database)
+    mock_db = MagicMock()
+    mock_services["job_db"].return_value = mock_db
     mock_db.parsed_jds.insert_one = AsyncMock()
 
     response = await async_client.post("/job/parse", json={"url": "https://example.com"})
@@ -64,13 +65,13 @@ async def test_parse_job_url(async_client, mock_services, mock_external_deps):
 
 
 @pytest.mark.asyncio
-async def test_compile_resume(async_client, mock_services, mock_external_deps):
+async def test_compile_resume(async_client, mock_services):
     """Test the resume compilation endpoint."""
-    # Mock DB from global fixture
-    mock_db = mock_external_deps["db"]
+    # Mock DB via mock_services (patches app.routers.resume.get_database)
+    mock_db = MagicMock()
+    mock_services["resume_db"].return_value = mock_db
 
-    # Mock units cursor
-    # For async for, we need an async iterator
+    # Mock units cursor - need a proper async iterator for Python 3.11 compat
     class AsyncIterator:
         def __init__(self, items):
             self.items = items

--- a/backend/tests/test_renderer.py
+++ b/backend/tests/test_renderer.py
@@ -30,7 +30,7 @@ def test_extract_header_info_empty():
 
 
 @pytest.mark.asyncio
-async def test_render_resume_success(mock_external_deps):
+async def test_render_resume_success():
     """Test successful resume rendering orchestration."""
     compile_id = "test_compile"
     master_version_id = "test_master"
@@ -40,7 +40,7 @@ async def test_render_resume_success(mock_external_deps):
         )
     ]
 
-    mock_db = mock_external_deps["db"]
+    mock_db = MagicMock()
     mock_db.atomic_units = MagicMock()
     # Mock the return value of find() to be an object that has __aiter__
     mock_cursor = AsyncMock()
@@ -49,20 +49,26 @@ async def test_render_resume_success(mock_external_deps):
 
     with (
         patch(
+            "app.services.renderer.get_database",
+            new_callable=AsyncMock,
+            return_value=mock_db,
+        ),
+        patch(
             "app.services.renderer.generate_text",
             new_callable=AsyncMock,
             return_value="LaTeX content",
         ),
         patch("app.services.renderer.os.makedirs"),
         patch("builtins.open"),
+        patch("app.services.renderer.subprocess.run") as mock_run,
         patch("app.services.renderer.os.path.exists", return_value=True),
         patch("app.services.renderer.shutil.move") as mock_move,
     ):
+        mock_run.return_value = MagicMock(stdout="Success", stderr="")
         result = await render_resume(compile_id, selected_units, master_version_id)
 
     assert "resume.pdf" in result
-    # We check if mock_external_deps["run"] was called because of the global mock
-    mock_external_deps["run"].assert_called_once()
+    mock_run.assert_called_once()
     mock_move.assert_called_once()
 
 
@@ -79,7 +85,7 @@ async def test_render_resume_failure():
     mock_db.atomic_units.find.return_value = mock_cursor
 
     with (
-        patch("app.services.renderer.get_database", return_value=mock_db),
+        patch("app.services.renderer.get_database", new_callable=AsyncMock, return_value=mock_db),
         patch(
             "app.services.renderer.generate_text",
             new_callable=AsyncMock,


### PR DESCRIPTION
## Summary
- **test_compile_resume**: Was configuring mock DB on `mock_external_deps["db"]` (conftest's `app.db.mongodb.get_database` patch) while the router's `get_database` is patched by `mock_services["resume_db"]`. The test was setting up the AsyncIterator on the wrong mock, causing `async for` to fail on Python 3.11 (CI uses 3.11, works by accident on 3.12 which added `__aiter__` to MagicMock).
- **test_render_resume_success**: Relied on conftest patching `app.db.mongodb.get_database`, but the renderer imports `get_database` locally — the conftest patch doesn't affect the renderer's reference. Now explicitly patches `app.services.renderer.get_database` with `AsyncMock`.

## Test plan
- [x] All 42 backend tests pass locally
- [ ] CI Backend Tests job should pass (was failing on all branches)