### PR TITLE
refactor: standardize project naming to ResMatch/resmatch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Deploy to DigitalOcean App Platform
         run: |
           # Get app ID (replace with your actual app ID or use doctl to find it)
-          APP_ID=$(doctl apps list --format ID,Spec.Name --no-header | grep restailor | awk '{print $1}')
+          APP_ID=$(doctl apps list --format ID,Spec.Name --no-header | grep resmatch | awk '{print $1}')
 
           if [ -n "$APP_ID" ]; then
             echo "Triggering deployment for app: $APP_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          NEXT_PUBLIC_API_URL: https://restailor-8qrvl.ondigitalocean.app
+          NEXT_PUBLIC_API_URL: https://resmatch-api.ondigitalocean.app
 
   # Backend tests
   backend-tests:

--- a/backend/.do/app.yaml
+++ b/backend/.do/app.yaml
@@ -1,12 +1,12 @@
 # DigitalOcean App Platform Specification
 # https://docs.digitalocean.com/products/app-platform/reference/app-spec/
 
-name: resume-compile-api
+name: resmatch-api
 
 services:
   - name: api
     github:
-      repo: your-username/restailor
+      repo: dsmithnautel/resmatch
       branch: main
       deploy_on_push: true
     source_dir: backend
@@ -25,9 +25,9 @@ services:
         type: SECRET
       - key: MONGODB_DATABASE
         scope: RUN_TIME
-        value: resume_compile
+        value: resmatch
       - key: CORS_ORIGINS
         scope: RUN_TIME
-        value: '["https://resume-compile.vercel.app","http://localhost:3000"]'
+        value: '["https://resmatch.vercel.app","https://www.resmatch.app","https://resmatch.app","http://localhost:3000"]'
     health_check:
       http_path: /health

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,7 +5,7 @@ GEMINI_API_KEY=your_gemini_api_key_here
 
 # MongoDB Atlas Connection String
 MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/?retryWrites=true&w=majority
-MONGODB_DATABASE=resume_compile
+MONGODB_DATABASE=resmatch
 
 # Server Configuration
 HOST=0.0.0.0

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,7 +13,7 @@ def parse_cors_origins() -> list[str]:
     default = [
         "http://localhost:3000",
         "http://localhost:3001",
-        "https://restailor.vercel.app",
+        "https://resmatch.vercel.app",
         "https://www.resmatch.app",
         "https://resmatch.app",
     ]
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
 
     # MongoDB Atlas
     mongodb_uri: str = "mongodb://localhost:27017"
-    mongodb_database: str = "resume_compile"
+    mongodb_database: str = "resmatch"
 
     # Server
     host: str = "0.0.0.0"
@@ -58,7 +58,7 @@ class Settings(BaseSettings):
     environment: str = "development"  # development, staging, production
 
     # CORS
-    cors_origins: list[str] = ["http://localhost:3000", "https://restailor.vercel.app"]
+    cors_origins: list[str] = ["http://localhost:3000", "https://resmatch.vercel.app"]
 
     class Config:
         env_file = ".env"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 os.environ["ENVIRONMENT"] = "test"
 os.environ["GEMINI_API_KEY"] = "test-key-for-testing"
 os.environ["MONGODB_URI"] = "mongodb://localhost:27017"
-os.environ["MONGODB_DATABASE"] = "resume_compile_test"
+os.environ["MONGODB_DATABASE"] = "resmatch_test"
 
 
 @pytest.fixture(autouse=True)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "resume-compile-frontend",
+  "name": "resmatch-frontend",
   "version": "1.0.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "restailor-2",
+  "name": "resmatch",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
## Summary

Standardizes project naming across the entire codebase from inconsistent references (restailor, resume_compile) to the unified **ResMatch/resmatch** branding.

## Changes

### Configuration Files
- **DigitalOcean App Platform** (`backend/.do/app.yaml`)
  - App name: `resume-compile-api` → `resmatch-api`
  - GitHub repo: `your-username/restailor` → `dsmithnautel/resmatch`
  - MongoDB database: `resume_compile` → `resmatch`
  - CORS origins: Updated to include all resmatch domains

- **Backend Config** (`backend/app/config.py`)
  - Default database: `resume_compile` → `resmatch`
  - Default CORS origins: `restailor.vercel.app` → `resmatch.vercel.app`

- **Environment Template** (`backend/.env.example`)
  - Database: `resume_compile` → `resmatch`

- **Test Configuration** (`backend/tests/conftest.py`)
  - Test database: `resume_compile_test` → `resmatch_test`

### CI/CD Workflows
- **CD Workflow** (`.github/workflows/cd.yml`)
  - App search: `grep restailor` → `grep resmatch`

- **CI Workflow** (`.github/workflows/ci.yml`)
  - API URL: `restailor-8qrvl.ondigitalocean.app` → `resmatch-api.ondigitalocean.app`

### Package Files
- **Frontend** (`frontend/package.json`)
  - Package name: `resume-compile-frontend` → `resmatch-frontend`

- **Root** (`package-lock.json`)
  - Package name: `restailor-2` → `resmatch`

## External Service Updates Required

After merging, these external services will need manual updates:

1. **MongoDB Atlas** - Rename database from `resume_compile` to `resmatch`
2. **DigitalOcean** - App will deploy as `resmatch-api` on next deployment
3. **Vercel** - May need project rename to match domain

Closes #12
